### PR TITLE
Add Windows support

### DIFF
--- a/.appveyor/msvc.bat
+++ b/.appveyor/msvc.bat
@@ -1,6 +1,7 @@
 @echo on
 
 set MESON_VERSION="0.50.0"
+set MUTEST_OUTPUT=tap
 
 :: Download Meson and Ninja, create install directory
 mkdir _build

--- a/.appveyor/msvc.bat
+++ b/.appveyor/msvc.bat
@@ -5,7 +5,7 @@ set MUTEST_OUTPUT=tap
 
 :: Download Meson and Ninja, create install directory
 mkdir _build
-mkdir graphene-shared-%MSVC_PLATFORM%
+mkdir mutest-static-%MSVC_PLATFORM%
 cd _build
 curl -LsSO https://github.com/mesonbuild/meson/releases/download/%MESON_VERSION%/meson-%MESON_VERSION%.tar.gz
 7z x meson-%MESON_VERSION%.tar.gz
@@ -22,16 +22,16 @@ cd ..
 cd _build
 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %MSVC_PLATFORM%
 @echo on
-C:\Python36\python.exe meson-%MESON_VERSION%\meson.py .. . -Dstatic=true --backend=ninja --prefix=%APPVEYOR_BUILD_FOLDER%\mutest-shared-%MSVC_PLATFORM% || goto :error
+C:\Python36\python.exe meson-%MESON_VERSION%\meson.py .. . -Dstatic=true --backend=ninja --prefix=%APPVEYOR_BUILD_FOLDER%\mutest-static-%MSVC_PLATFORM% || goto :error
 ninja || goto :error
 ninja test || goto :error
 ninja install || goto :error
 cd ..
 
 :: Copy license into install directory and create .zip file
-copy LICENSE mutest-shared-%MSVC_PLATFORM% || goto :error
-dir mutest-shared-%MSVC_PLATFORM% /s /b || goto :error
-7z a -tzip mutest-shared-win-%MSVC_PLATFORM%.zip mutest-shared-%MSVC_PLATFORM% || goto :error
+copy LICENSE.txt mutest-static-%MSVC_PLATFORM% || goto :error
+dir mutest-static-%MSVC_PLATFORM% /s /b || goto :error
+7z a -tzip mutest-static-%MSVC_PLATFORM%.zip mutest-static-%MSVC_PLATFORM% || goto :error
 
 goto :EOF
 

--- a/.appveyor/msvc.bat
+++ b/.appveyor/msvc.bat
@@ -22,7 +22,7 @@ cd ..
 cd _build
 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %MSVC_PLATFORM%
 @echo on
-C:\Python36\python.exe meson-%MESON_VERSION%\meson.py .. . --backend=ninja --prefix=%APPVEYOR_BUILD_FOLDER%\mutest-shared-%MSVC_PLATFORM% || goto :error
+C:\Python36\python.exe meson-%MESON_VERSION%\meson.py .. . -Dstatic=true --backend=ninja --prefix=%APPVEYOR_BUILD_FOLDER%\mutest-shared-%MSVC_PLATFORM% || goto :error
 ninja || goto :error
 ninja test || goto :error
 ninja install || goto :error

--- a/.appveyor/msvc.bat
+++ b/.appveyor/msvc.bat
@@ -1,6 +1,6 @@
 @echo on
 
-set MESON_VERSION="0.50.0"
+set MESON_VERSION="0.50.1"
 set MUTEST_OUTPUT=tap
 
 :: Download Meson and Ninja, create install directory

--- a/.appveyor/msys2.sh
+++ b/.appveyor/msys2.sh
@@ -25,6 +25,7 @@ cd _build
 ninja
 
 # Test
+export MUTEST_OUTPUT=tap
 meson test || {
   cat meson-logs/testlog.txt
   exit 1

--- a/.appveyor/msys2.sh
+++ b/.appveyor/msys2.sh
@@ -25,4 +25,7 @@ cd _build
 ninja
 
 # Test
-meson test
+meson test || {
+  cat meson-logs/testlog.txt
+  exit 1
+}

--- a/.appveyor/msys2.sh
+++ b/.appveyor/msys2.sh
@@ -20,7 +20,7 @@ pacman --noconfirm -S --needed \
     mingw-w64-$MSYS2_ARCH-pkg-config \
 
 # Build
-meson _build
+meson _build -Dstatic=true
 cd _build
 ninja
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -12,6 +12,7 @@ test_headers = [
   'sys/ioctl.h',
   'sys/types.h',
   'unistd.h',
+  'fcntl.h',
 ]
 
 foreach h: test_headers
@@ -22,15 +23,23 @@ foreach h: test_headers
 endforeach
 
 test_functions = [
-  [ 'isatty', 'unistd.h' ]
+  [ 'isatty', 'unistd.h' ],
+  [ 'clock_gettime', 'time.h' ],
 ]
 
 foreach f: test_functions
-  if cc.has_function(f[0], prefix: '#include <@0@>'.format(f[1]))
+  if cc.has_function(f[0], prefix: '#define _GNU_SOURCE\n#include <@0@>'.format(f[1]))
     define = 'HAVE_' + f[0].underscorify().to_upper()
     config_h.set(define, 1)
   endif
 endforeach
+
+if host_machine.system() == 'windows'
+  config_h.set('OS_WINDOWS', 1)
+  if cc.has_function('QueryPerformanceCounter', prefix: '#include <windows.h>')
+    config_h.set('HAVE_QUERY_PERFORMANCE_COUNTER', 1)
+  endif
+endif
 
 configure_file(output: 'config.h', configuration: config_h)
 

--- a/src/mutest-expect-funcs.c
+++ b/src/mutest-expect-funcs.c
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier: MIT
  */
 
-#include "config.h"
-
 #include "mutest-private.h"
 
 #include <string.h>

--- a/src/mutest-expect-types.c
+++ b/src/mutest-expect-types.c
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier: MIT
  */
 
-#include "config.h"
-
 #include "mutest-private.h"
 
 #include <stdlib.h>

--- a/src/mutest-expect-types.c
+++ b/src/mutest-expect-types.c
@@ -175,7 +175,7 @@ mutest_string_value (const char *value)
     mutest_oom_abort ();
 
   res->expect_type = MUTEST_EXPECT_STR;
-  res->expect.v_str.str = strdup (value);
+  res->expect.v_str.str = mutest_strdup (value);
   if (res->expect.v_str.str == NULL)
     mutest_oom_abort ();
 

--- a/src/mutest-expect.c
+++ b/src/mutest-expect.c
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier: MIT
  */
 
-#include "config.h"
-
 #include "mutest-private.h"
 
 #include <string.h>

--- a/src/mutest-expect.c
+++ b/src/mutest-expect.c
@@ -181,7 +181,7 @@ mutest_collect_string (mutest_expect_type_t value_type MUTEST_UNUSED,
   mutest_expect_res_t *retval = mutest_expect_res_alloc (MUTEST_EXPECT_STR);
 
   char *str = va_arg (args, char *);
-  retval->expect.v_str.str = strdup (str);
+  retval->expect.v_str.str = mutest_strdup (str);
   retval->expect.v_str.len = str != NULL ? strlen (str) : 0;
 
   return retval;

--- a/src/mutest-expect.c
+++ b/src/mutest-expect.c
@@ -17,7 +17,7 @@
 static mutest_expect_res_t *
 mutest_collect_true (mutest_expect_type_t value_type MUTEST_UNUSED,
                      mutest_collect_type_t collect_type MUTEST_UNUSED,
-                     va_list args MUTEST_UNUSED)
+                     va_list *args MUTEST_UNUSED)
 {
   mutest_expect_res_t *retval = mutest_expect_res_alloc (MUTEST_EXPECT_BOOLEAN);
 
@@ -29,7 +29,7 @@ mutest_collect_true (mutest_expect_type_t value_type MUTEST_UNUSED,
 static mutest_expect_res_t *
 mutest_collect_false (mutest_expect_type_t value_type MUTEST_UNUSED,
                       mutest_collect_type_t collect_type MUTEST_UNUSED,
-                      va_list args MUTEST_UNUSED)
+                      va_list *args MUTEST_UNUSED)
 {
   mutest_expect_res_t *retval = mutest_expect_res_alloc (MUTEST_EXPECT_BOOLEAN);
 
@@ -41,7 +41,7 @@ mutest_collect_false (mutest_expect_type_t value_type MUTEST_UNUSED,
 static mutest_expect_res_t *
 mutest_collect_null (mutest_expect_type_t value_type MUTEST_UNUSED,
                      mutest_collect_type_t collect_type MUTEST_UNUSED,
-                     va_list args MUTEST_UNUSED)
+                     va_list *args MUTEST_UNUSED)
 {
   mutest_expect_res_t *retval = mutest_expect_res_alloc (MUTEST_EXPECT_POINTER);
 
@@ -53,7 +53,7 @@ mutest_collect_null (mutest_expect_type_t value_type MUTEST_UNUSED,
 static mutest_expect_res_t *
 mutest_collect_nan (mutest_expect_type_t value_type MUTEST_UNUSED,
                     mutest_collect_type_t collect_type MUTEST_UNUSED,
-                    va_list args MUTEST_UNUSED)
+                    va_list *args MUTEST_UNUSED)
 {
   mutest_expect_res_t *retval = mutest_expect_res_alloc (MUTEST_EXPECT_FLOAT);
 
@@ -66,7 +66,7 @@ mutest_collect_nan (mutest_expect_type_t value_type MUTEST_UNUSED,
 static mutest_expect_res_t *
 mutest_collect_infinity (mutest_expect_type_t value_type MUTEST_UNUSED,
                          mutest_collect_type_t collect_type MUTEST_UNUSED,
-                         va_list args MUTEST_UNUSED)
+                         va_list *args MUTEST_UNUSED)
 {
   mutest_expect_res_t *retval = mutest_expect_res_alloc (MUTEST_EXPECT_FLOAT);
 
@@ -79,11 +79,11 @@ mutest_collect_infinity (mutest_expect_type_t value_type MUTEST_UNUSED,
 static mutest_expect_res_t *
 mutest_collect_boolean (mutest_expect_type_t value_type MUTEST_UNUSED,
                         mutest_collect_type_t collect_type MUTEST_UNUSED,
-                        va_list args)
+                        va_list *args)
 {
   mutest_expect_res_t *retval = mutest_expect_res_alloc (MUTEST_EXPECT_BOOLEAN);
 
-  int val = va_arg (args, int);
+  int val = va_arg (*args, int);
   retval->expect.v_bool = !!val;
 
   return retval;
@@ -92,7 +92,7 @@ mutest_collect_boolean (mutest_expect_type_t value_type MUTEST_UNUSED,
 static mutest_expect_res_t *
 mutest_collect_number (mutest_expect_type_t value_type,
                        mutest_collect_type_t collect_type,
-                       va_list args)
+                       va_list *args)
 {
   bool collect_int = (collect_type & MUTEST_COLLECT_INT) != 0;
   bool collect_float = (collect_type & MUTEST_COLLECT_FLOAT) != 0;
@@ -136,28 +136,28 @@ mutest_collect_number (mutest_expect_type_t value_type,
       break;
 
     case MUTEST_EXPECT_INT:
-      retval->expect.v_int = va_arg (args, int);
+      retval->expect.v_int = va_arg (*args, int);
       break;
 
     case MUTEST_EXPECT_FLOAT:
-      retval->expect.v_float.value = va_arg (args, double);
+      retval->expect.v_float.value = va_arg (*args, double);
       if (collect_precision)
-        retval->expect.v_float.tolerance = va_arg (args, double);
+        retval->expect.v_float.tolerance = va_arg (*args, double);
       else
         retval->expect.v_float.tolerance = DBL_EPSILON;
       break;
 
     case MUTEST_EXPECT_INT_RANGE:
-      retval->expect.v_irange.min = va_arg (args, int);
-      retval->expect.v_irange.max = va_arg (args, int);
+      retval->expect.v_irange.min = va_arg (*args, int);
+      retval->expect.v_irange.max = va_arg (*args, int);
 
       if (retval->expect.v_irange.min > retval->expect.v_irange.max)
         mutest_assert_if_reached ("invalid range");
       break;
 
     case MUTEST_EXPECT_FLOAT_RANGE:
-      retval->expect.v_frange.min = va_arg (args, double);
-      retval->expect.v_frange.max = va_arg (args, double);
+      retval->expect.v_frange.min = va_arg (*args, double);
+      retval->expect.v_frange.max = va_arg (*args, double);
 
       if (retval->expect.v_frange.min > retval->expect.v_frange.max)
         mutest_assert_if_reached ("invalid range");
@@ -176,11 +176,11 @@ mutest_collect_number (mutest_expect_type_t value_type,
 static mutest_expect_res_t *
 mutest_collect_string (mutest_expect_type_t value_type MUTEST_UNUSED,
                        mutest_collect_type_t collect_type MUTEST_UNUSED,
-                       va_list args)
+                       va_list *args)
 {
   mutest_expect_res_t *retval = mutest_expect_res_alloc (MUTEST_EXPECT_STR);
 
-  char *str = va_arg (args, char *);
+  char *str = va_arg (*args, char *);
   retval->expect.v_str.str = mutest_strdup (str);
   retval->expect.v_str.len = str != NULL ? strlen (str) : 0;
 
@@ -190,11 +190,11 @@ mutest_collect_string (mutest_expect_type_t value_type MUTEST_UNUSED,
 static mutest_expect_res_t *
 mutest_collect_pointer (mutest_expect_type_t value_type MUTEST_UNUSED,
                         mutest_collect_type_t collect_type MUTEST_UNUSED,
-                        va_list args)
+                        va_list *args)
 {
   mutest_expect_res_t *retval = mutest_expect_res_alloc (MUTEST_EXPECT_POINTER);
 
-  retval->expect.v_pointer = va_arg (args, void *);
+  retval->expect.v_pointer = va_arg (*args, void *);
 
   return retval;
 }
@@ -202,7 +202,7 @@ mutest_collect_pointer (mutest_expect_type_t value_type MUTEST_UNUSED,
 static mutest_expect_res_t *
 mutest_collect_scalar (mutest_expect_type_t value_type,
                        mutest_collect_type_t collect_type,
-                       va_list args)
+                       va_list *args)
 {
   bool collect_matching = (collect_type & MUTEST_COLLECT_MATCHING_TYPE) != 0;
   bool collect_string = (collect_type & MUTEST_COLLECT_STRING) != 0;
@@ -394,7 +394,7 @@ mutest_expect_full (const char *file,
               repr = matchers[i].repr;
               check = matchers[i].collector (value->expect_type,
                                              matchers[i].collect_rule,
-                                             args);
+                                             &args);
               break;
             }
         }

--- a/src/mutest-main.c
+++ b/src/mutest-main.c
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier: MIT
  */
 
-#include "config.h"
-
 #include "mutest-private.h"
 
 #include <errno.h>

--- a/src/mutest-private.h
+++ b/src/mutest-private.h
@@ -189,6 +189,11 @@ struct _mutest_suite_t
 # define mutest_unlikely(x)     (x)
 #endif
 
+#ifdef OS_WINDOWS
+# define strdup(x) _strdup(x)
+# define write(fd,buf,count) _write(fd, buf, count)
+#endif
+
 mutest_expect_res_t *
 mutest_expect_res_alloc (mutest_expect_type_t type);
 

--- a/src/mutest-private.h
+++ b/src/mutest-private.h
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include "config.h"
+
 #include "mutest.h"
 
 #include <stdint.h>

--- a/src/mutest-private.h
+++ b/src/mutest-private.h
@@ -13,6 +13,7 @@
 
 #include "mutest.h"
 
+#include <stdio.h>
 #include <stdint.h>
 #include <stdarg.h>
 
@@ -190,8 +191,7 @@ struct _mutest_suite_t
 #endif
 
 #ifdef OS_WINDOWS
-# define strdup(x) _strdup(x)
-# define write(fd,buf,count) _write(fd, buf, count)
+# define strdup(x) mutest_strdup(x)
 #endif
 
 mutest_expect_res_t *
@@ -200,8 +200,11 @@ mutest_expect_res_alloc (mutest_expect_type_t type);
 void
 mutest_expect_res_free (mutest_expect_res_t *res);
 
+char *
+mutest_strdup (const char *str);
+
 void
-mutest_print (int fd,
+mutest_print (FILE *stram,
               const char *first_fragment,
               ...) MUTEST_NULL_TERMINATED;
 

--- a/src/mutest-private.h
+++ b/src/mutest-private.h
@@ -89,7 +89,7 @@ typedef enum {
 
 typedef mutest_expect_res_t *(* mutest_collect_func_t) (mutest_expect_type_t expect_type,
                                                         mutest_collect_type_t collect_type,
-                                                        va_list args);
+                                                        va_list *args);
 
 struct _mutest_expect_res_t
 {

--- a/src/mutest-private.h
+++ b/src/mutest-private.h
@@ -190,10 +190,6 @@ struct _mutest_suite_t
 # define mutest_unlikely(x)     (x)
 #endif
 
-#ifdef OS_WINDOWS
-# define strdup(x) mutest_strdup(x)
-#endif
-
 mutest_expect_res_t *
 mutest_expect_res_alloc (mutest_expect_type_t type);
 

--- a/src/mutest-spec.c
+++ b/src/mutest-spec.c
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier: MIT
  */
 
-#include "config.h"
-
 #include "mutest-private.h"
 
 #include <string.h>

--- a/src/mutest-suite.c
+++ b/src/mutest-suite.c
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier: MIT
  */
 
-#include "config.h"
-
 #include "mutest-private.h"
 
 #include <string.h>

--- a/src/mutest-utils.c
+++ b/src/mutest-utils.c
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier: MIT
  */
 
-#include "config.h"
-
 #include "mutest-private.h"
 
 #include <stdarg.h>

--- a/src/mutest-utils.c
+++ b/src/mutest-utils.c
@@ -23,6 +23,7 @@
 #endif
 #ifdef OS_WINDOWS
 #include <windows.h>
+#include <io.h>
 #endif
 
 #define ANSI_ESCAPE             "\033"

--- a/src/mutest-utils.c
+++ b/src/mutest-utils.c
@@ -39,14 +39,6 @@
 #define MUTEST_UNDERLINE_DEFAULT        ANSI_ESCAPE "[4;39m"
 #define MUTEST_DIM_DEFAULT              ANSI_ESCAPE "[2;39m"
 
-#if defined(OS_WINDOWS) && !defined(STDOUT_FILENO)
-# define STDOUT_FILENO _fileno(stdout)
-#endif
-
-#if defined(OS_WINDOWS) && !defined(STDERR_FILENO)
-# define STDERR_FILENO _fileno(stderr)
-#endif
-
 // mutest_get_current_time:
 //
 // Returns: the current time, in microseconds
@@ -91,8 +83,24 @@ mutest_get_current_time (void)
 # error "muTest requires a monotonic clock implementation"
 #endif
 
+char *
+mutest_strdup (const char *str)
+{
+  if (str == NULL)
+    return NULL;
+
+  size_t len = strlen (str);
+  char *res = malloc (len * sizeof (char));
+  if (res == NULL)
+    mutest_oom_abort ();
+
+  memcpy (res, str, len * sizeof (char));
+
+  return res;
+}
+
 void
-mutest_print (int fd,
+mutest_print (FILE *stream,
               const char *first_fragment,
               ...)
 {
@@ -103,15 +111,24 @@ mutest_print (int fd,
   const char *fragment = first_fragment;
   while (fragment != NULL)
     {
+#ifdef OS_WINDOWS
       if (fragment[0] != '\0')
-        write (fd, fragment, strlen (fragment));
+        fprintf (stream, "%s", fragment);
+#else
+      if (fragment[0] != '\0')
+        write (fileno (stream), fragment, strlen (fragment));
+#endif
 
       fragment = va_arg (args, char *);
     }
 
   va_end (args);
 
-  write (fd, "\n", 1);
+#ifdef OS_WINDOWS
+  fputc ('\n', stream);
+#else
+  write (fileno (stream), "\n", 1);
+#endif
 }
 
 void
@@ -131,14 +148,14 @@ mutest_assert_message (const char *file,
   snprintf (lstr, 32, "%d", line);
 
   if (mutest_use_colors ())
-    mutest_print (STDERR_FILENO,
+    mutest_print (stderr,
                   MUTEST_COLOR_RED, "ERROR", MUTEST_COLOR_NONE, ": ",
                   file, ":", lstr, ":", func != NULL ? func : "<local>",
                   " ",
                   message,
                   NULL);
   else
-    mutest_print (STDERR_FILENO,
+    mutest_print (stderr,
                   "ERROR: ", file, ":", lstr, ":", func != NULL ? func : "<local>", " ",
                   message,
                   NULL);
@@ -170,13 +187,13 @@ static void
 mocha_suite_preamble (mutest_suite_t *suite)
 {
   if (mutest_use_colors ())
-    mutest_print (STDOUT_FILENO,
+    mutest_print (stdout,
                   "\n",
                   "  ",
                   MUTEST_BOLD_DEFAULT, suite->description, MUTEST_COLOR_NONE,
                   NULL);
   else
-    mutest_print (STDOUT_FILENO,
+    mutest_print (stdout,
                   "\n",
                   "  ", suite->description,
                   NULL);
@@ -189,37 +206,37 @@ mocha_expect_result (mutest_expect_t *expect)
     {
     case MUTEST_RESULT_PASS:
       if (mutest_use_colors ())
-        mutest_print (STDOUT_FILENO,
+        mutest_print (stdout,
                       "     ",
                       MUTEST_COLOR_GREEN, " ✓ ", MUTEST_DIM_DEFAULT, expect->description,
                       MUTEST_COLOR_NONE,
                       NULL);
       else
-        mutest_print (STDOUT_FILENO,
+        mutest_print (stdout,
                       "      ✓ ", expect->description,
                       NULL);
       break;
 
     case MUTEST_RESULT_FAIL:
       if (mutest_use_colors ())
-        mutest_print (STDOUT_FILENO,
+        mutest_print (stdout,
                       "     ",
                       MUTEST_COLOR_RED, " ✗ ", expect->description, MUTEST_COLOR_NONE,
                       NULL);
       else
-        mutest_print (STDOUT_FILENO,
+        mutest_print (stdout,
                       "      ✗ ", expect->description,
                       NULL);
       break;
 
     case MUTEST_RESULT_SKIP:
       if (mutest_use_colors ())
-        mutest_print (STDOUT_FILENO,
+        mutest_print (stdout,
                       "     ",
                       MUTEST_COLOR_YELLOW, " - ", expect->description, MUTEST_COLOR_NONE,
                       NULL);
       else
-        mutest_print (STDOUT_FILENO,
+        mutest_print (stdout,
                       "      - ", expect->description,
                       NULL);
       break;
@@ -229,7 +246,7 @@ mocha_expect_result (mutest_expect_t *expect)
 static void
 mocha_spec_preamble (mutest_spec_t *spec)
 {
-  mutest_print (STDOUT_FILENO,
+  mutest_print (stdout,
                 "    ",
                 spec->description,
                 NULL);
@@ -253,7 +270,7 @@ mocha_spec_results (mutest_spec_t *spec)
 
   if (mutest_use_colors ())
     {
-      mutest_print (STDOUT_FILENO,
+      mutest_print (stdout,
                     "\n",
                     "      ",
                     MUTEST_COLOR_GREEN, passing_s, MUTEST_COLOR_NONE, " ",
@@ -261,21 +278,21 @@ mocha_spec_results (mutest_spec_t *spec)
                     NULL);
 
       if (spec->skip != 0)
-        mutest_print (STDOUT_FILENO,
+        mutest_print (stdout,
                       "      ",
                       MUTEST_COLOR_YELLOW, skipped_s, MUTEST_COLOR_NONE,
                       NULL);
 
       if (spec->fail != 0)
-        mutest_print (STDOUT_FILENO,
+        mutest_print (stdout,
                       "      ",
                       MUTEST_COLOR_RED, failing_s, MUTEST_COLOR_NONE,
                       NULL);
 
-      mutest_print (STDOUT_FILENO, "", NULL);
+      mutest_print (stdout, "", NULL);
     }
   else
-    mutest_print (STDOUT_FILENO,
+    mutest_print (stdout,
                   "\n",
                   "      ", passing_s, " ", delta_s, "\n",
                   "      ", skipped_s, "\n",
@@ -306,7 +323,7 @@ mocha_total_results (mutest_state_t *state)
 
   if (mutest_use_colors ())
     {
-      mutest_print (STDOUT_FILENO,
+      mutest_print (stdout,
                     "\n",
                     MUTEST_UNDERLINE_DEFAULT, "Total", MUTEST_COLOR_NONE, "\n",
                     MUTEST_COLOR_GREEN, passing_s, MUTEST_COLOR_NONE, " ",
@@ -314,19 +331,19 @@ mocha_total_results (mutest_state_t *state)
                     NULL);
 
       if (state->skip != 0)
-        mutest_print (STDOUT_FILENO,
+        mutest_print (stdout,
                       MUTEST_COLOR_YELLOW, skipped_s, MUTEST_COLOR_NONE,
                       NULL);
 
       if (state->fail != 0)
-        mutest_print (STDOUT_FILENO,
+        mutest_print (stdout,
                       MUTEST_COLOR_RED, failing_s, MUTEST_COLOR_NONE,
                       NULL);
 
-      mutest_print (STDOUT_FILENO, "", NULL);
+      mutest_print (stdout, "", NULL);
     }
   else
-    mutest_print (STDOUT_FILENO,
+    mutest_print (stdout,
                   "\n",
                   "  Total\n",
                   "  ", passing_s, " ", delta_s, "\n",
@@ -347,19 +364,19 @@ tap_expect_result (mutest_expect_t *expect)
   switch (expect->result)
     {
     case MUTEST_RESULT_PASS:
-      mutest_print (STDOUT_FILENO,
+      mutest_print (stdout,
                     "ok ", num, " ", expect->description,
                     NULL);
       break;
 
     case MUTEST_RESULT_FAIL:
-      mutest_print (STDOUT_FILENO,
+      mutest_print (stdout,
                     "not ok ", num, " ", expect->description,
                     NULL);
       break;
 
     case MUTEST_RESULT_SKIP:
-      mutest_print (STDOUT_FILENO,
+      mutest_print (stdout,
                     "ok ", num, " # skip: ", expect->description,
                     NULL);
       break;
@@ -369,27 +386,27 @@ tap_expect_result (mutest_expect_t *expect)
 static void
 tap_spec_preamble (mutest_spec_t *spec)
 {
-  mutest_print (STDOUT_FILENO, "# ", spec->description, NULL);
+  mutest_print (stdout, "# ", spec->description, NULL);
 }
 
 static void
 tap_suite_preamble (mutest_suite_t *suite)
 {
-  mutest_print (STDOUT_FILENO, "# ", suite->description, NULL);
+  mutest_print (stdout, "# ", suite->description, NULL);
 }
 
 static void
 tap_total_results (mutest_state_t *state)
 {
   if (state->n_tests == state->skip)
-    mutest_print (STDOUT_FILENO, "1..0 # skip", NULL);
+    mutest_print (stdout, "1..0 # skip", NULL);
   else
     {
       char plan[128];
 
       snprintf (plan, 128, "1..%d", state->n_tests);
 
-      mutest_print (STDOUT_FILENO, plan, NULL);
+      mutest_print (stdout, plan, NULL);
     }
 }
 
@@ -493,7 +510,7 @@ mutest_print_expect_fail (mutest_expect_t *expect,
 
   if (mutest_use_colors ())
     {
-      mutest_print (STDOUT_FILENO,
+      mutest_print (stdout,
                     "      ",
                     MUTEST_COLOR_RED, "Assertion failure: ",
                     lhs, comparison, rhs,
@@ -502,7 +519,7 @@ mutest_print_expect_fail (mutest_expect_t *expect,
     }
   else
     {
-      mutest_print (STDOUT_FILENO,
+      mutest_print (stdout,
                     "      ",
                     "Assertion failure: ",
                     lhs, " ", comparison, " ", rhs,

--- a/src/mutest-utils.c
+++ b/src/mutest-utils.c
@@ -89,7 +89,7 @@ mutest_strdup (const char *str)
   if (str == NULL)
     return NULL;
 
-  size_t len = strlen (str);
+  size_t len = strlen (str) + 1;
   char *res = malloc (len * sizeof (char));
   if (res == NULL)
     mutest_oom_abort ();


### PR DESCRIPTION
The whole point of writing µTest to replace the GLib testing API was to allow faster builds on Windows with MSYS2, and running the Graphene test suite with MSVC.