### PR TITLE
Replace getenv()

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -27,6 +27,7 @@ endforeach
 test_functions = [
   [ 'isatty', 'unistd.h' ],
   [ 'clock_gettime', 'time.h' ],
+  [ '_dupenv_s', 'stdlib.h' ],
 ]
 
 foreach f: test_functions

--- a/src/mutest-main.c
+++ b/src/mutest-main.c
@@ -145,14 +145,15 @@ update_term_caps (void)
       return;
     }
 
-  const char *env = getenv ("FORCE_COLOR");
+  char *env = mutest_getenv ("FORCE_COLOR");
   if (env != NULL && env[0] != '\0')
     {
       global_state.use_colors = true;
+      free (env);
       return;
     }
 
-  env = getenv ("TERM");
+  env = mutest_getenv ("TERM");
   if (env != NULL)
     {
       if (strncmp (env, "xterm", 5) == 0 ||
@@ -163,14 +164,17 @@ update_term_caps (void)
           strncmp (env, "screen", 6) == 0)
         {
           global_state.use_colors = true;
-          return;
         }
+
+      free (env);
+      return;
     }
 
-  env = getenv ("COLORTERM");
+  env = mutest_getenv ("COLORTERM");
   if (env != NULL)
     {
       global_state.use_colors = true;
+      free (env);
       return;
     }
 
@@ -194,6 +198,19 @@ update_term_size (void)
 #endif
 }
 
+static void
+update_output_format (void)
+{
+  char *env = mutest_getenv ("MUTEST_OUTPUT");
+
+  if (env != NULL && strcmp (env, "tap") == 0)
+    global_state.output_format = MUTEST_OUTPUT_TAP;
+  else
+    global_state.output_format = MUTEST_OUTPUT_MOCHA;
+
+  free (env);
+}
+
 void
 mutest_before (mutest_hook_func_t hook)
 {
@@ -214,12 +231,7 @@ mutest_init (void)
 
   update_term_caps ();
   update_term_size ();
-
-  const char *env = getenv ("MUTEST_OUTPUT");
-  if (env != NULL && strcmp (env, "tap") == 0)
-    global_state.output_format = MUTEST_OUTPUT_TAP;
-  else
-    global_state.output_format = MUTEST_OUTPUT_MOCHA;
+  update_output_format ();
 
   global_state.start_time = mutest_get_current_time ();
 

--- a/src/mutest-private.h
+++ b/src/mutest-private.h
@@ -238,6 +238,9 @@ mutest_expect_res_free (mutest_expect_res_t *res);
 char *
 mutest_strdup (const char *str);
 
+char *
+mutest_getenv (const char *env_name);
+
 void
 mutest_print (FILE *stram,
               const char *first_fragment,

--- a/src/mutest-utils.c
+++ b/src/mutest-utils.c
@@ -86,6 +86,12 @@ mutest_strdup (const char *str)
   return res;
 }
 
+char *
+mutest_getenv (const char *str)
+{
+  return mutest_strdup (getenv (str));
+}
+
 void
 mutest_print (FILE *stream,
               const char *first_fragment,

--- a/src/mutest-utils.c
+++ b/src/mutest-utils.c
@@ -89,7 +89,18 @@ mutest_strdup (const char *str)
 char *
 mutest_getenv (const char *str)
 {
+#ifdef HAVE__DUPENV_S
+  size_t len = 0;
+  char *res = NULL;
+
+  errno_t err = _dupenv_s (&res, &len, str);
+  if (err)
+    return NULL;
+
+  return res;
+#else
   return mutest_strdup (getenv (str));
+#endif
 }
 
 void


### PR DESCRIPTION
Windows will warn when using `getenv()`; to avoid that, we should use `_dupenv_s()`, a safe replacement for `getenv()` on Windows.