### PR TITLE
ci: Add coverage report

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+repo_token: YJi21gyXWjx2BsvS8HRvfwjgXTJaQTqw1

--- a/.travis-ci/Dockerfile
+++ b/.travis-ci/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update -qq \
     && apt-get install --no-install-recommends -qq -y \
         clang \
         gcc \
+        git \
         locales \
         ninja-build \
         pkg-config \
@@ -12,6 +13,7 @@ RUN apt-get update -qq \
         python3-pip \
         python3-setuptools \
         python3-wheel \
+        python3-yaml \
     && rm -rf /usr/share/doc/* /usr/share/man/*
 
 RUN locale-gen C.UTF-8 && /usr/sbin/update-locale LANG=C.UTF-8
@@ -19,3 +21,5 @@ RUN locale-gen C.UTF-8 && /usr/sbin/update-locale LANG=C.UTF-8
 ENV LANG=C.UTF-8 LANGUAGE=C.UTF-8 LC_ALL=C.UTF-8
 
 RUN pip3 install meson==0.50.1
+
+RUN pip3 install cpp-coveralls

--- a/.travis-ci/run-tests.sh
+++ b/.travis-ci/run-tests.sh
@@ -2,13 +2,14 @@
 
 set -x
 
-meson --prefix /usr "$@" _build . || exit $?
+builddir="_build"
+srcdir=`pwd`
 
-cd _build
+CFLAGS='-coverage -ftest-coverage -fprofile-arcs'
 
-ninja || exit $?
-meson test || exit $?
+meson --prefix /usr "$@" $builddir $srcdir || exit $?
 
-cd ..
+ninja -C $builddir || exit $?
+meson test -C $builddir || exit $?
 
-rm -rf _build
+cpp-coveralls -r . -b $builddir -i src -i ../src -e tests -e ../tests --gcov-options='\-lp'

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
  - **Linux**: [![Build Status](https://travis-ci.org/ebassi/mutest.svg?branch=master)](https://travis-ci.org/ebassi/mutest)
  - **Windows**: [![Build status](https://ci.appveyor.com/api/projects/status/1ghtdpt42u3vy8s9/branch/master?svg=true)](https://ci.appveyor.com/project/ebassi/mutest/branch/master)
+ - [![Coverage Status](https://coveralls.io/repos/github/ebassi/mutest/badge.svg?branch=HEAD)](https://coveralls.io/github/ebassi/mutest?branch=HEAD)
 
 ## What is µTest
 


### PR DESCRIPTION
We use Coveralls.io, which provides a service integrated with Travis and
GitHub to report coverage data. The coverage report is generated via
gcov and the cpp-coveralls Python module.