### PR TITLE
Do not depend on GNU libc'isms for signed infinities

### DIFF
--- a/src/mutest-matchers.c
+++ b/src/mutest-matchers.c
@@ -228,7 +228,7 @@ mutest_to_be_positive_infinity (mutest_expect_t *e,
   mutest_expect_res_t *value = e->value;
 
   if (value->expect_type == MUTEST_EXPECT_FLOAT)
-    return isinf (value->expect.v_float.value) == 1;
+    return isinf (value->expect.v_float.value) != 0 && signbit (value->expect.v_float.value) == 0;
 
   return false;
 }
@@ -240,7 +240,7 @@ mutest_to_be_negative_infinity (mutest_expect_t *e,
   mutest_expect_res_t *value = e->value;
 
   if (value->expect_type == MUTEST_EXPECT_FLOAT)
-    return isinf (value->expect.v_float.value) == -1;
+    return isinf (value->expect.v_float.value) != 0 && signbit (value->expect.v_float.value) != 0;
 
   return false;
 }


### PR DESCRIPTION
The behaviour of isinf() that is mandated by the C99 spec is to return a
non-zero value if the value is an infinity, regardless of sign. GNU libc
returns -1 for negative infinities and 1 for positive ones, but other
standard C libraries might be more strict.